### PR TITLE
Time str update

### DIFF
--- a/metroman_consolidation.py
+++ b/metroman_consolidation.py
@@ -98,7 +98,6 @@ class process_reaches():
         t[:] = self.tswot
 
         for key in list(data_dict[reach_id].keys()):
-            print(key)
             set_group = dsout.createGroup(key)
 
             #                 'A0hat': A0hat,
@@ -125,20 +124,16 @@ class process_reaches():
     def extract_mm_data(self, a_file, reach_id):
         mm_data=ncf.Dataset(a_file)
         present_reaches = os.path.basename(a_file).split('_')[0].split('-')
-        print(present_reaches, reach_id) 
         reach_index = os.path.basename(a_file).split('_')[0].split('-').index(str(reach_id))
-        print(reach_index)
 
         # nr=np.max(mm_data['nr'][:].data)
         nr=mm_data.dimensions['nr'].size
-        # if nr != len(reachids):
-        #     print('Error! nr in the file must match the number of reaches in the filename')
 
         # determine number of times in the set file
         tsf=list(mm_data['t'][:].data) #setfile number of times - same for all reaches    
         ntsf=len(tsf)
 
-        print('there are ',ntsf,'times in the set file')
+
 
         # grab the discharge array
         Qsetfile=mm_data['allq'][reach_index][:].filled(np.nan)
@@ -160,7 +155,6 @@ class process_reaches():
                 'qu_setfile': qu_setfile,
                 'Qsetfile':Qsetfile
             }
-        print('average', self.data_dict[reach_id])
         # self.data_dict[reach_id]['average'] = {
         #         'A0hat': self.data_dict[reach_id]['average']['A0hat'].append([A0hat]),
         #         'nahat': self.data_dict[reach_id]['average']['nahat'].append([nahat]),
@@ -175,25 +169,15 @@ class process_reaches():
             if a_set != 'average':
                 for a_var in list(self.data_dict[self.reach_id][a_set].keys()):
                     self.data_dict[self.reach_id]['average'][a_var].append(self.data_dict[self.reach_id][a_set][a_var])
-        print('first')
-        # print(self.data_dict[self.reach_id]['average']['A0hat'])
-        # for outthing in self.data_dict[self.reach_id]['average']['A0hat']:
-        #     print('test')
-        #     print(outthing)
-        # raise
         for a_var in list(self.data_dict[self.reach_id]['average'].keys()):
             if len(self.data_dict[self.reach_id]['average'][a_var])>1:
-                print('average here', a_var)
                 if not np.isnan(self.data_dict[self.reach_id]['average'][a_var]).all():
-                    print('not all nan')
                     average_array_axis0 = np.nanmean(self.data_dict[self.reach_id]['average'][a_var][:], axis=0)
                     self.data_dict[self.reach_id]['average'][a_var] = average_array_axis0
                 else:
-                    print('all nan')
                     self.data_dict[self.reach_id]['average'][a_var] = self.data_dict[self.reach_id]['average'][a_var][0]
             else:
                 self.data_dict[self.reach_id]['average'][a_var] = self.data_dict[self.reach_id]['average'][a_var][0]
-        print(self.data_dict[self.reach_id]['average'])
 
     def parse_data(self):
 

--- a/metroman_consolidation.py
+++ b/metroman_consolidation.py
@@ -55,6 +55,7 @@ class process_reaches():
 
     def find_reach_ids(self):
         all_output_files = glob.glob(os.path.join(self.indir, f'{self.cont_number}*.nc'))
+        print(all_output_files)
         all_reach_ids = []
         all_reach_ids = [os.path.basename(i).split('_')[0].split('-') for i in all_output_files]
         all_reach_ids = list(set(sum(all_reach_ids, [])))
@@ -96,18 +97,17 @@ class process_reaches():
             t_str[i] = single_time_str
             
         for key in list(data_dict[reach_id].keys()):
-            if key != 'average':
-                set_group = dsout.createGroup(key)
-                allq = set_group.createVariable("allq", "f8", ( "nt"), fill_value=fillvalue)
-                allq[:] = data_dict[reach_id][key]['Qsetfile']
-                A0 = set_group.createVariable("A0hat", "f8", fill_value=fillvalue)
-                A0[:]= data_dict[reach_id][key]['A0hat']
-                na = set_group.createVariable("nahat", "f8", fill_value=fillvalue)
-                na[:]=data_dict[reach_id][key]['nahat']
-                x1 = set_group.createVariable("x1hat", "f8",  fill_value=fillvalue)
-                x1[:]=data_dict[reach_id][key]['x1hat']
-                allqu = set_group.createVariable("q_u", "f8", ("nt"), fill_value=fillvalue)
-                allqu[:]=data_dict[reach_id][key]['qu_setfile']
+            set_group = dsout.createGroup(key)
+            allq = set_group.createVariable("allq", "f8", ( "nt"), fill_value=fillvalue)
+            allq[:] = data_dict[reach_id][key]['Qsetfile']
+            A0 = set_group.createVariable("A0hat", "f8", fill_value=fillvalue)
+            A0[:]= data_dict[reach_id][key]['A0hat']
+            na = set_group.createVariable("nahat", "f8", fill_value=fillvalue)
+            na[:]=data_dict[reach_id][key]['nahat']
+            x1 = set_group.createVariable("x1hat", "f8",  fill_value=fillvalue)
+            x1[:]=data_dict[reach_id][key]['x1hat']
+            allqu = set_group.createVariable("q_u", "f8", ("nt"), fill_value=fillvalue)
+            allqu[:]=data_dict[reach_id][key]['qu_setfile']
 
         return dsout 
 
@@ -203,7 +203,7 @@ class process_reaches():
 def main():
     """Make a jazz noise here"""
     args = get_args() 
-    indir = '/mnt/flpe'
+    indir = '/mnt/flpe/metroman'
     input_mnt_path = '/mnt/input'
     output_dir = ''
     index = args.index

--- a/metroman_consolidation.py
+++ b/metroman_consolidation.py
@@ -203,9 +203,9 @@ class process_reaches():
 def main():
     """Make a jazz noise here"""
     args = get_args() 
-    indir = '/mnt/flpe/metroman'
-    input_mnt_path = '/mnt/input'
-    output_dir = ''
+    indir = '/mnt/data/flpe/sets'
+    input_mnt_path = '/mnt/data/input'
+    output_dir = '/mnt/data/flpe'
     index = args.index
     process_reaches(indir, input_mnt_path, index, output_dir)
 


### PR DESCRIPTION
Previously the nt dimension in the output files was None. This was a bug allowing all of the data to be different sizes and not line up with the time_str key.

Now, there is a global time_str variable that is the same one from the timeseries files. Each of the metroman outputs are parsed and filled in a way that their q predictions line up to the time_str, with the same dimensions. Each set that the reach was included in will be a group. There will always be an 'average' group that combines all of the predictions for that reach across sets.